### PR TITLE
BrowserSync should run with https by default since mobile web browser…

### DIFF
--- a/gulp/tasks/browser_sync.js
+++ b/gulp/tasks/browser_sync.js
@@ -4,7 +4,8 @@ var gulp        = require('gulp');
 gulp.task('browserSync', ['build'], function() {
   browserSync.init(['build/**'], {
     server: {
-      baseDir: ['build', 'src']
+      baseDir: ['build', 'src'],
+      https: true,
     }
   });
 });


### PR DESCRIPTION
…s won't share location information otherwise

Please see: https://browsersync.io/docs/options
Browsersync supplies a self-signed certificate for development - https://wearejh.com/development/https-support-added-browsersync/